### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Facter.pm
+++ b/lib/Facter.pm
@@ -27,7 +27,7 @@
 
 use v6;
 
-class Facter;
+unit class Facter;
 
 use Facter::Util::Fact;
 use Facter::Util::Collection;

--- a/lib/Facter/Util/Collection.pm
+++ b/lib/Facter/Util/Collection.pm
@@ -1,6 +1,6 @@
 # Manage which facts exist and how we access them.  Largely just a wrapper
 # around a hash of facts.
-class Facter::Util::Collection;
+unit class Facter::Util::Collection;
 
 #se Facter;
 #se Facter::Util::Fact;

--- a/lib/Facter/Util/Confine.pm
+++ b/lib/Facter/Util/Confine.pm
@@ -5,7 +5,7 @@
 # for the resolution mechanism to be suitable.
 #
 
-class Facter::Util::Confine;
+unit class Facter::Util::Confine;
 
 use Facter::Util::Values;
 

--- a/lib/Facter/Util/Fact.pm
+++ b/lib/Facter/Util/Fact.pm
@@ -1,4 +1,4 @@
-class Facter::Util::Fact;
+unit class Facter::Util::Fact;
 
 use Facter::Util::Resolution;
 

--- a/lib/Facter/Util/Loader.pm
+++ b/lib/Facter/Util/Loader.pm
@@ -2,7 +2,7 @@
 
 use v6;
 
-class Facter::Util::Loader;
+unit class Facter::Util::Loader;
 
 has $!loaded_all is rw = False;
 

--- a/lib/Facter/Util/Resolution.pm
+++ b/lib/Facter/Util/Resolution.pm
@@ -8,7 +8,7 @@
 # suitable.
 #
 
-class Facter::Util::Resolution;
+unit class Facter::Util::Resolution;
 
 #equire 'timeout'
 #equire 'rbconfig'


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.