### PR TITLE
Put space-significant expression in single quotes

### DIFF
--- a/lib/Facter/Util/Resolution.pm
+++ b/lib/Facter/Util/Resolution.pm
@@ -67,7 +67,7 @@ method exec($code, $interpreter = $INTERPRETER) {
             Facter.debug("Trying to find which '$binary'");
             $path = qqx{which '$binary' 2>/dev/null}.chomp;
             # we don't have the binary necessary
-            return if $path eq "" or $path.match(/Command not found\./);
+            return if $path eq "" or $path.match(/'Command not found.'/);
         }
         Facter.debug("path=$path");
         return unless $path.IO ~~ :e;


### PR DESCRIPTION
This is because in Perl6 regexps, spaces are no longer significant.  Thus,
if one wants to match a string containing spaces, either wrap the string in
single quotes or specify the `:s` adverb to tell the regexp engine that
spaces are significant.  I chose here the non-adverb form since now it's no
longer necessary to escape the '.'.