### PR TITLE
Remove 'is rw' modifier on attrs with '!' twigil

### DIFF
--- a/lib/Facter.pm
+++ b/lib/Facter.pm
@@ -44,7 +44,7 @@ our $timing = 0;
 our $collection;
 
 # Private members
-has @!search_path is rw = ();
+has @!search_path = ();
 
 method collection {
     $collection //= Facter::Util::Collection.new

--- a/lib/Facter/Util/Collection.pm
+++ b/lib/Facter/Util/Collection.pm
@@ -7,8 +7,8 @@ class Facter::Util::Collection;
 use Facter::Util::Loader;
 
 # Private members
-has %!facts is rw = ();
-has $!loader is rw;
+has %!facts = ();
+has $!loader;
 
 # Return a fact object by name.  If you use this, you still have to call
 # 'value' on it to retrieve the actual value.

--- a/lib/Facter/Util/Fact.pm
+++ b/lib/Facter/Util/Fact.pm
@@ -4,13 +4,13 @@ use Facter::Util::Resolution;
 
 our $TIMEOUT = 5;
 
-has $!value is rw;
-has $!suitable is rw = False;
+has $!value;
+has $!suitable = False;
 
 has $.name is rw = "";
 has $.ldapname is rw = "";
 has @.resolves is rw = ();
-has $!searching is rw = False;
+has $!searching = False;
 
 # Create a new fact, with no resolution mechanisms.
 method initialize($name, %options = ()) {

--- a/lib/Facter/Util/Loader.pm
+++ b/lib/Facter/Util/Loader.pm
@@ -4,7 +4,7 @@ use v6;
 
 class Facter::Util::Loader;
 
-has $!loaded_all is rw = False;
+has $!loaded_all = False;
 
 # Load all resolutions for a single fact.
 method load($fact) {

--- a/lib/Facter/Util/Resolution.pm
+++ b/lib/Facter/Util/Resolution.pm
@@ -13,8 +13,8 @@ class Facter::Util::Resolution;
 #equire 'timeout'
 #equire 'rbconfig'
 
-has $!value is rw;
-has $!suitable is rw;
+has $!value;
+has $!suitable;
 
 has $.code is rw;
 has $.interpreter is rw;


### PR DESCRIPTION
Object attributes with the '!' twigil don't require the 'is rw' modifier,
since they already are read-write.  This commit removes the superfluous
modifiers and the tests still pass.