### PR TITLE
Make the module semi-functional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Makefile
 blib
+.precomp

--- a/lib/Facter/Debug.pm
+++ b/lib/Facter/Debug.pm
@@ -1,19 +1,19 @@
 use v6;
 
 role Facter::Debug {
-    our $debug = 0;
+    has $!debug = 0;
 
     multi method debugging {
-        return $debug != 0
+        return $!debug != 0
     }
 
     # Set debugging on or off (1/0)
     multi method debugging($bit) {
         if $bit {
-            $debug = 1;
+            $!debug = 1;
         }
         else {
-            $debug = 0;
+            $!debug = 0;
         }
     }
 

--- a/lib/Facter/Util/Loader.pm
+++ b/lib/Facter/Util/Loader.pm
@@ -130,10 +130,6 @@ method load_file($file) {
 # Load facts from the environment.  If no name is provided,
 # all will be loaded.
 method load_env($fact = "") {
-
-    # TODO Iterate over %*ENV not possible?
-    return;
-
     # Load from the environment, if possible
     for %*ENV.kv -> $name, $value {
 

--- a/lib/Facter/Util/Loader.pm
+++ b/lib/Facter/Util/Loader.pm
@@ -139,7 +139,7 @@ method load_env($fact = "") {
 
         # If a fact name was specified,
         # skip anything that doesn't match it.
-        next if $fact and $env_name != $fact;
+        next if $fact and $env_name ne $fact;
 
         Facter.add($env_name, $value);
 

--- a/lib/Facter/Util/Resolution.pm
+++ b/lib/Facter/Util/Resolution.pm
@@ -24,7 +24,7 @@ has $.name is rw;
 has $.timeout is rw;
 has @.confines is rw;
 
-our $WINDOWS = $*OS ~~ m:i/mswin|win32|dos|mingw|cygwin/;
+our $WINDOWS = ~$*DISTRO ~~ m:i/mswin|win32|dos|mingw|cygwin/;
 our $INTERPRETER = $WINDOWS ?? 'cmd.exe' !! '/bin/sh';
 our $HAVE_WHICH;
 

--- a/lib/Facter/perl6os.pm
+++ b/lib/Facter/perl6os.pm
@@ -1,6 +1,6 @@
 Facter.add(<perl6os>, sub ($f) {
     $f.setcode(block => sub {
-        $*OS.Str
+        $*DISTRO.Str
     });
 })
 

--- a/t/000-load-classes.t
+++ b/t/000-load-classes.t
@@ -11,5 +11,4 @@ use Facter::Util::Values;
 
 ok(1, 'Facter main classes loaded');
 
-done;
-
+done-testing;

--- a/t/basic.t
+++ b/t/basic.t
@@ -19,7 +19,7 @@ ok($fact.^can("value"), "fact object has a value() method");
 
 my $lsbdistname = $facter.fact($test-fact).value;
 ok($lsbdistname, "fact '$test-fact' is loaded");
-is($lsbdistname, $*OS, "test fact has correct value");
+is($lsbdistname, $*DISTRO, "test fact has correct value");
 
 # Unused for now...
 #@search_dirs = $facter.search_path;

--- a/t/basic.t
+++ b/t/basic.t
@@ -28,5 +28,4 @@ is($lsbdistname, $*DISTRO, "test fact has correct value");
 diag("Collection object:" ~ $coll.perl);
 diag("Search dirs:" ~ @search_dirs.perl);
 
-done;
-
+done-testing;

--- a/t/resolution-exec.t
+++ b/t/resolution-exec.t
@@ -8,5 +8,4 @@ my $uname_res = Facter::Util::Resolution.exec('uname -a');
 diag('uname-res: ' ~ $uname_res);
 ok($uname_res, 'uname -a should result in something');
 
-done;
-
+done-testing;

--- a/t/to-hash.t
+++ b/t/to-hash.t
@@ -11,5 +11,4 @@ ok(%facts, 'Facter.to_hash call produces some result');
 
 is(%facts<perl6os>, $*DISTRO, 'perl6os fact has the correct value');
 
-done;
-
+done-testing;

--- a/t/to-hash.t
+++ b/t/to-hash.t
@@ -9,7 +9,7 @@ my %facts = $facter.to_hash;
 
 ok(%facts, 'Facter.to_hash call produces some result');
 
-is(%facts<perl6os>, $*OS, 'perl6os fact has the correct value');
+is(%facts<perl6os>, $*DISTRO, 'perl6os fact has the correct value');
 
 done;
 

--- a/t/values.t
+++ b/t/values.t
@@ -15,5 +15,4 @@ for @values -> $test_case, $expected_result {
     );
 }
 
-done;
-
+done-testing;


### PR DESCRIPTION
I attempted to fix the module during the squashathon.

So it compiles and works now, and some tests in basic.t pass. However, it fails on:
```
my $fact = $facter.fact($test-fact);
ok($fact, "test fact is loaded");
```

I was trying to add missing pieces but the module seems to be unfinished? I think the test file needs to set `facter_perl6os=perl6os` env var, or something like that. But I didn't manage to get it to chooch.

BTW I think PRs https://github.com/cosimo/perl6-facter/pull/3 https://github.com/cosimo/perl6-facter/pull/4 and https://github.com/cosimo/perl6-facter/pull/5 can be closed (no longer needed).